### PR TITLE
Fix Jenkinsfile groups_var sourcing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,8 @@ node('master') {
   env.TOKEN = readFile('/var/run/secrets/kubernetes.io/serviceaccount/token').trim()
   env.OC_CMD = "oc --token=${env.TOKEN} --server=${ocpApiServer} --certificate-authority=/run/secrets/kubernetes.io/serviceaccount/ca.crt --namespace=${env.NAMESPACE}"
 
-  def groupVars = readYaml file: '.openshift-applier/inventory/group_vars/all.yml'
+  def workspace = pwd()
+  def groupVars = readYaml file: "${workspace}@script/.openshift-applier/inventory/group_vars/all.yml"
   env.APP_NAME = """${groupVars.app_name}"""
   
   println "Starting Pipeline for Application: ${APP_NAME}"


### PR DESCRIPTION
Currently the Jenkinsfile fails on sourcing the `groups_var` file: 
`def groupVars = readYaml file: '.openshift-applier/inventory/group_vars/all.yml'`

This is because it attempts to source it at : `/var/lib/jenkins/jobs/omp-ci-cd/jobs/omp-ci-cd-omp-data-api-pipeline/workspace`, which does not exist. By grabbing `pwd()` and then sourcing the file from there, this fixes this issue (which grabs the file from `/var/lib/jenkins/jobs/omp-ci-cd/jobs/omp-ci-cd-omp-data-api-pipeline/workspace@script` and does exist).

cc/ @logandonley 