### PR TITLE
Add backup jobs

### DIFF
--- a/.openshift-applier/inventory/group_vars/all.yml
+++ b/.openshift-applier/inventory/group_vars/all.yml
@@ -33,6 +33,19 @@ db_deploy:
   MEMORY_LIMIT: "512Mi"
   IMAGESTREAM_NAMESPACE: "openshift" 
 
+backup_deploy:
+  APP_NAME: "{{ app_name }}-db"
+  SCHEDULE: "@hourly"
+  SUCCESS_JOBS_HISTORY_LIMIT: 2
+  FAILED_JOBS_HISTORY_LIMIT: 2
+  MONGODB_VERSION: "3.4"
+  VOLUME_CAPACITY: "1Gi"
+  BACKUP_PATH: "/opt/app-root/src"
+  AWS_ID: "my-id"
+  AWS_KEY: "my-key"
+  AWS_REGION: "us-east-1"
+  AWS_BUCKET_NAME: "my-bucket"
+
 openshift_cluster_content:
   - object: projectrequest
     content:
@@ -72,4 +85,24 @@ openshift_cluster_content:
         params_from_vars: "{{ db_deploy }}"
         namespace: "{{ dev_namespace }}"
         tags:
-        - db-deploy
+          - db-deploy
+          - mongo-deploy
+
+  - object: backup-deploy
+    content:
+      - name: "{{ app_name }}-backup-deploy-{{ dev_namespace }}"
+        template: "{{ inventory_dir }}/../templates/omp-db/db-backup.yml"
+        params_from_vars: "{{ backup_deploy }}"
+        namespace: "{{ dev_namespace }}"
+        tags:
+          - db-deploy
+          - backup-deploy
+          - db-backup-deploy
+      - name: "{{ app_name }}-aws-backup-deploy-{{dev_namespace }}"
+        template: "{{ inventory_dir }}/../templates/omp-db/aws-backup.yml"
+        params_from_vars: "{{ backup_deploy }}"
+        namespace: "{{ dev_namespace }}"
+        tags:
+          - aws-backup-deploy
+          - backup-deploy
+          - db-deploy

--- a/.openshift-applier/templates/omp-db/aws-backup.yml
+++ b/.openshift-applier/templates/omp-db/aws-backup.yml
@@ -1,0 +1,149 @@
+---
+kind: "Template"
+apiVersion: "v1"
+metadata:
+  name: "${APP_NAME}-aws-backup"
+  annotations:
+    description: "Scheduled task to move database backups to AWS"
+    iconClass: "icon-shadowman"
+objects:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: ${APP_NAME}-aws-backup
+  spec:
+    dockerImageRepository: docker.io/mesosphere/aws-cli
+    lookupPolicy:
+      local: true
+    tags:
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: docker.io/mesosphere/aws-cli:latest
+      importPolicy: {}
+      name: "latest"
+      referencePolicy:
+        type: Source
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: docker.io/mesosphere/aws-cli:1.14.5
+      importPolicy: {}
+      name: "1.14.5"
+      referencePolicy:
+        type: Source
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "${APP_NAME}-aws-backup-creds"
+    labels:
+      template: "${APP_NAME}-aws-backup"
+  stringData:
+    AWS_ACCESS_KEY_ID: ${AWS_ID}
+    AWS_SECRET_ACCESS_KEY: ${AWS_KEY}
+    AWS_DEFAULT_REGION: ${AWS_REGION}
+
+- kind: "CronJob"
+  apiVersion: "batch/v1beta1"
+  metadata:
+    name: "${APP_NAME}-aws-backup"
+    labels:
+      template: "${APP_NAME}-aws-backup"
+  spec:
+    schedule: "${SCHEDULE}"
+    concurrencyPolicy: "Forbid"
+    successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
+    failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: "${APP_NAME}-aws-backup"
+                image: "${APP_NAME}-aws-backup:latest"
+                command:
+                - /bin/sh
+                - -i
+                - -c
+                - aws s3 sync ${BACKUP_PATH} s3://${AWS_BUCKET_NAME}
+                envFrom:
+                  - name: AWS_ID
+                    secretRef:
+                      name: "${APP_NAME}-aws-backup-creds"
+                      key: AWS_ACCESS_KEY_ID
+                  - name: AWS_KEY
+                    secretRef:
+                      key: AWS_SECRET_ACCESS_KEY
+                      name: "${APP_NAME}-aws-backup-creds"
+                  - name: AWS_REGION
+                    secretRef:
+                      key: AWS_DEFAULT_REGION
+                      name: ${APP_NAME}-aws-backup-creds
+                volumeMounts:
+                  - mountPath: "${BACKUP_PATH}"
+                    name: "${APP_NAME}-backup"
+            volumes:
+              - name: ${APP_NAME}-backup 
+                persistentVolumeClaim:
+                  claimName: "${APP_NAME}-backup"
+            restartPolicy: "Never"
+            terminationGracePeriodSeconds: 30
+            activeDeadlineSeconds: 500
+            dnsPolicy: "ClusterFirst"
+
+parameters:
+  - name: "APP_NAME"
+    displayName: "Job Name"
+    description: "Name of the Scheduled Job to Create."
+    value: "omp-db"
+    required: true
+
+  - name: "SCHEDULE"
+    displayName: "Cron Schedule"
+    description: "Cron Schedule to Execute the Job"
+    value: "@hourly"
+    required: true
+
+  - name: "SUCCESS_JOBS_HISTORY_LIMIT"
+    displayName: "Successful Job History Limit"
+    description: "The number of successful jobs that will be retained"
+    value: "5"
+    required: true
+
+  - name: "FAILED_JOBS_HISTORY_LIMIT"
+    displayName: "Failed Job History Limit"
+    description: "The number of failed jobs that will be retained"
+    value: "5"
+    required: true
+
+  - name: BACKUP_PATH
+    displayName: "DB Backup Path"
+    description: "Backup Path for MongoDB exports"
+    required: true
+    value: /opt/app-root/src
+
+  - name: AWS_ID
+    displayName: "AWS Access ID"
+    description: "Access ID to authenticate to AWS"
+    required: true
+
+  - name: AWS_KEY
+    displayName: "AWS Access Key"
+    description: "Access key to authenticate to AWS"
+    required: true
+
+  - name: AWS_REGION
+    displayName: "Default AWS Region"
+    description: "Default AWS Region to use"
+    required: true
+
+  - name: AWS_BUCKET_NAME
+    displayName: "Name of AWS Bucket"
+    description: "Name of bucket to sync database restores to"
+    required: true
+    value: "my-test-bucket"
+
+labels:
+  template: "${APP_NAME}-aws-backup"

--- a/.openshift-applier/templates/omp-db/db-backup.yml
+++ b/.openshift-applier/templates/omp-db/db-backup.yml
@@ -1,0 +1,122 @@
+---
+kind: "Template"
+apiVersion: "v1"
+metadata:
+  name: "${APP_NAME}-backup"
+  annotations:
+    description: "Scheduled task to perform mongodb backup"
+    iconClass: "icon-shadowman"
+objects:
+#TODO: Set up the PVC so that it's set to retain instead of delete
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: "${APP_NAME}-backup"
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- kind: "CronJob"
+  apiVersion: "batch/v1beta1"
+  metadata:
+    name: "${APP_NAME}-backup"
+    labels:
+      template: "${APP_NAME}-backup"
+  spec:
+    schedule: "${SCHEDULE}"
+    concurrencyPolicy: "Forbid"
+    successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
+    failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: "${APP_NAME}-backup"
+                image: "mongo:${MONGODB_VERSION}"
+                command:
+                - /bin/sh
+                - -i
+                - -c
+#TODO: We should write the db dump to an archive, which will save some space later
+                - mongodump -h ${APP_NAME} -d $DATABASE_NAME --username $DATABASE_USER --password $DATABASE_PASSWORD --out ${BACKUP_PATH}/${APP_NAME}-$(date +"%Y%m%d_%H%M%S")
+                envFrom:
+                  - name: DATABASE_CONNECTION_STRING
+                    secretRef:
+                      name: "${APP_NAME}"
+                      key: DATABASE_CONNECTION_STRING
+                  - name: MONGODB_USER
+                    secretRef:
+                      key: DATABASE_USER
+                      name: ${APP_NAME}
+                  - name: MONGODB_PASSWORD
+                    secretRef:
+                      key: DATABASE_PASSWORD
+                      name: ${APP_NAME}
+                  - name: MONGODB_ADMIN_PASSWORD
+                    secretRef:
+                      key: DATABASE_ADMIN_PASSWORD
+                      name: ${APP_NAME}
+                  - name: MONGODB_DATABASE
+                    secretRef:
+                      key: DATABASE_NAME
+                      name: ${APP_NAME}
+                volumeMounts:
+                  - mountPath: "${BACKUP_PATH}"
+                    name: "${APP_NAME}-backup"
+            volumes:
+              - name: ${APP_NAME}-backup 
+                persistentVolumeClaim:
+                  claimName: "${APP_NAME}-backup"
+            restartPolicy: "Never"
+            terminationGracePeriodSeconds: 30
+            activeDeadlineSeconds: 500
+            dnsPolicy: "ClusterFirst"
+
+parameters:
+  - name: "APP_NAME"
+    displayName: "Job Name"
+    description: "Name of the Scheduled Job to Create."
+    value: "omp-db"
+    required: true
+
+  - name: "SCHEDULE"
+    displayName: "Cron Schedule"
+    description: "Cron Schedule to Execute the Job"
+    value: "@hourly"
+    required: true
+
+  - name: "SUCCESS_JOBS_HISTORY_LIMIT"
+    displayName: "Successful Job History Limit"
+    description: "The number of successful jobs that will be retained"
+    value: "5"
+    required: true
+
+  - name: "FAILED_JOBS_HISTORY_LIMIT"
+    displayName: "Failed Job History Limit"
+    description: "The number of failed jobs that will be retained"
+    value: "5"
+    required: true
+
+  - name: "MONGODB_VERSION"
+    displayName: "Image Tag"
+    description: "Image Tag to use for the container."
+    required: true
+    value: "3.4"
+
+  - name: VOLUME_CAPACITY
+    displayName: "Volume Capacity"
+    description: "Volume space available for data, e.g. 512Mi, 2Gi."
+    value: "1Gi"
+    required: true
+
+  - name: BACKUP_PATH
+    displayName: "DB Backup Path"
+    description: "Backup Path for MongoDB exports"
+    required: true
+    value: /opt/app-root/src
+
+labels:
+  template: "${APP_NAME}-backup"


### PR DESCRIPTION
#### What does this PR do?
Add backup jobs to take mongo backups and then copy them to AWS

#### How should this be tested?
This can be deployed with the rest of the application using run.sh. You'll need to provide better values in `all.yml` to both be able to test this faster (cronjobs are set to run `@hourly` by default) and to provide appropriate AWS creds

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @rht-labs/omp
