### PR TITLE
Adding Swagger Spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "express-joi-validation": "^0.3.0",
     "joi": "^14.3.0",
     "mongodb": "^3.1.9",
-    "mongoose": "^5.3.10"
+    "mongoose": "^5.3.10",
+    "swagger-ui-express": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,12 @@ app.get("/", (req, res) =>
   })
 );
 
+var swaggerUi = require('swagger-ui-express'), swaggerDocument = require('./swagger.json');
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+//app.use('/api/v1', router);
+
+
 // Import v1 routes
 require("./routes/v1/routes")(app);
 

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -39,21 +39,21 @@
     "application/json"
   ],
   "paths": {
-    "/users": {
+    "/users/{tags}": {
       "get": {
         "tags": [
           "Users"
         ],
-        "description": "Returns the status of something",
+        "description": "Queery for users belonging to one or more tags",
         "operationId": "get_user",
         "produces": [
           "application/json"
         ],
         "parameters": [
           {
-            "name": "ID",
+            "name": "tags",
             "in": "path",
-            "description": "ID to fetch",
+            "description": "User tags to fetch",
             "required": true,
             "type": "string"
           }
@@ -62,36 +62,7 @@
           "200": {
             "description": "response",
             "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "description": "what this API does",
-        "operationId": "post_user",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "Job Parameters",
-            "in": "body",
-            "description": "Job to add to the database",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "create response",
-            "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/user_response"
             }
           }
         }
@@ -100,45 +71,16 @@
         "tags": [
           "Users"
         ],
-        "description": "Deletes a something",
+        "description": "Delete users belonging to one or more tags",
         "operationId": "delete_user",
         "produces": [
           "application/json"
         ],
         "parameters": [
           {
-            "name": "someVariable",
+            "name": "tags",
             "in": "path",
-            "description": "ID to delete",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "delete response",
-            "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        }
-      }
-    },
-    "/customers": {
-      "get": {
-        "tags": [
-          "Customers"
-        ],
-        "description": "Returns the status of something",
-        "operationId": "get_customer",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "ID",
-            "in": "path",
-            "description": "ID to fetch",
+            "description": "User tags to fetch",
             "required": true,
             "type": "string"
           }
@@ -147,16 +89,105 @@
           "200": {
             "description": "response",
             "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/delete_response"
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "description": "Creates a new user entry in database",
+        "operationId": "post_user",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "User Parameters",
+            "in": "body",
+            "description": "User to add to the database",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user_request"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create response",
+            "schema": {
+              "$ref": "#/definitions/user_response"
+            }
+          }
+        }
+      }
+    },
+    "/customers/{tags}": {
+      "get": {
+        "tags": [
+          "Customers"
+        ],
+        "description": "Queery for customers belonging to one or more tags",
+        "operationId": "get_customer",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "path",
+            "description": "Customer tags to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/customer_response"
             }
           }
         }
       },
+      "delete": {
+        "tags": [
+          "Customers"
+        ],
+        "description": "Delete customers belonging to one or more tags",
+        "operationId": "delete_customer",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "path",
+            "description": "Customer tags to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/delete_response"
+            }
+          }
+        }
+      }
+    },
+    "/customers": {
       "post": {
         "tags": [
           "Customers"
         ],
-        "description": "what this API does",
+        "description": "Creates a new customer entry in database",
         "operationId": "post_customer",
         "produces": [
           "application/json"
@@ -165,10 +196,10 @@
           {
             "name": "Job Parameters",
             "in": "body",
-            "description": "Job to add to the database",
+            "description": "Customer to add to the database",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/customer_request"
             }
           }
         ],
@@ -176,54 +207,27 @@
           "200": {
             "description": "create response",
             "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Customers"
-        ],
-        "description": "Deletes a something",
-        "operationId": "delete_customer",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "someVariable",
-            "in": "path",
-            "description": "ID to delete",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "delete response",
-            "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/customer_response"
             }
           }
         }
       }
     },
-    "/clusters": {
+    "/clusters/{tags}": {
       "get": {
         "tags": [
           "Clusters"
         ],
-        "description": "Returns the status of something",
+        "description": "Queery for clusters belonging to one or more tags",
         "operationId": "get_cluster",
         "produces": [
           "application/json"
         ],
         "parameters": [
           {
-            "name": "ID",
+            "name": "tags",
             "in": "path",
-            "description": "ID to fetch",
+            "description": "Cluster tags to fetch",
             "required": true,
             "type": "string"
           }
@@ -232,16 +236,45 @@
           "200": {
             "description": "response",
             "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/cluster_response"
             }
           }
         }
       },
+      "delete": {
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Delete users belonging to one or more tags",
+        "operationId": "delete_cluster",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "path",
+            "description": "Cluster tags to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/delete_response"
+            }
+          }
+        }
+      }
+    },
+    "/clusters": {
       "post": {
         "tags": [
           "Clusters"
         ],
-        "description": "what this API does",
+        "description": "Creates a new cluster entry in database",
         "operationId": "post_cluster",
         "produces": [
           "application/json"
@@ -250,10 +283,10 @@
           {
             "name": "Job Parameters",
             "in": "body",
-            "description": "Job to add to the database",
+            "description": "Cluster to add to the database",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/cluster_request"
             }
           }
         ],
@@ -261,54 +294,27 @@
           "200": {
             "description": "create response",
             "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Clusters"
-        ],
-        "description": "Deletes a something",
-        "operationId": "delete_cluster",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "someVariable",
-            "in": "path",
-            "description": "ID to delete",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "delete response",
-            "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/cluster_response"
             }
           }
         }
       }
     },
-    "/residencies": {
+    "/residencies/{tags}": {
       "get": {
         "tags": [
           "Residencies"
         ],
-        "description": "Returns the status of something",
+        "description": "Queery for residencies belonging to one or more tags",
         "operationId": "get_residency",
         "produces": [
           "application/json"
         ],
         "parameters": [
           {
-            "name": "ID",
+            "name": "tags",
             "in": "path",
-            "description": "ID to fetch",
+            "description": "Residency tags to fetch",
             "required": true,
             "type": "string"
           }
@@ -317,16 +323,45 @@
           "200": {
             "description": "response",
             "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/residency_response"
             }
           }
         }
       },
+      "delete": {
+        "tags": [
+          "Residencies"
+        ],
+        "description": "Delete residencies belonging to one or more tags",
+        "operationId": "delete_residency",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "path",
+            "description": "User tags to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/delete_response"
+            }
+          }
+        }
+      }
+    },
+    "/residencies": {
       "post": {
         "tags": [
           "Residencies"
         ],
-        "description": "what this API does",
+        "description": "Creates a new residency entry in database",
         "operationId": "post_residency",
         "produces": [
           "application/json"
@@ -335,10 +370,10 @@
           {
             "name": "Job Parameters",
             "in": "body",
-            "description": "Job to add to the database",
+            "description": "Residency to add to the database",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/residency_request"
             }
           }
         ],
@@ -346,54 +381,27 @@
           "200": {
             "description": "create response",
             "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Residencies"
-        ],
-        "description": "Deletes a something",
-        "operationId": "delete_residency",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "someVariable",
-            "in": "path",
-            "description": "ID to delete",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "delete response",
-            "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/residency_response"
             }
           }
         }
       }
     },
-    "/groups": {
+    "/groups/{tags}": {
       "get": {
         "tags": [
           "Groups"
         ],
-        "description": "Returns the status of something",
+        "description": "Queery for groups belonging to one or more tags",
         "operationId": "get_group",
         "produces": [
           "application/json"
         ],
         "parameters": [
           {
-            "name": "ID",
+            "name": "tags",
             "in": "path",
-            "description": "ID to fetch",
+            "description": "Group tags to fetch",
             "required": true,
             "type": "string"
           }
@@ -402,36 +410,7 @@
           "200": {
             "description": "response",
             "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Groups"
-        ],
-        "description": "what this API does",
-        "operationId": "post_group",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "Job Parameters",
-            "in": "body",
-            "description": "Job to add to the database",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/customers"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "create response",
-            "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/group_response"
             }
           }
         }
@@ -440,25 +419,56 @@
         "tags": [
           "Groups"
         ],
-        "description": "Deletes a something",
+        "description": "Delete users belonging to one or more tags",
         "operationId": "delete_group",
         "produces": [
           "application/json"
         ],
         "parameters": [
           {
-            "name": "someVariable",
+            "name": "tags",
             "in": "path",
-            "description": "ID to delete",
+            "description": "Group tags to fetch",
             "required": true,
             "type": "string"
           }
         ],
         "responses": {
           "200": {
-            "description": "delete response",
+            "description": "response",
             "schema": {
-              "$ref": "#/definitions/customers"
+              "$ref": "#/definitions/delete_response"
+            }
+          }
+        }
+      }
+    },
+    "/groups": {
+      "post": {
+        "tags": [
+          "Groups"
+        ],
+        "description": "Creates a new group entry in database",
+        "operationId": "post_group",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Job Parameters",
+            "in": "body",
+            "description": "Group to add to the database",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/group_request"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create response",
+            "schema": {
+              "$ref": "#/definitions/group_response"
             }
           }
         }
@@ -466,13 +476,9 @@
     }
   },
   "definitions": {
-    "users": {
+    "user_request": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "user_name": {
           "type": "string"
         },
@@ -483,7 +489,8 @@
           "type": "string"
         },
         "expiration_date": {
-          "type": "string"
+          "type": "string",
+          "format": "date"
         },
         "email": {
           "type": "string"
@@ -499,13 +506,46 @@
         }
       }
     },
-    "customers": {
+    "user_response": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "user_name": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "expiration_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "email": {
+            "type": "string"
+          },
+          "identity_providers": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "customer_request": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "customer_name": {
           "type": "string"
         },
@@ -517,12 +557,29 @@
         }
       }
     },
-    "clusters": {
+    "customer_response": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customer_name": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "cluster_request": {
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "logging": {
           "type": "boolean"
         },
@@ -549,17 +606,51 @@
         }
       }
     },
-    "residencies": {
+    "cluster_response": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "logging": {
+            "type": "boolean"
+          },
+          "metrics": {
+            "type": "boolean"
+          },
+          "size": {
+            "type": "string"
+          },
+          "ha": {
+            "type": "boolean"
+          },
+          "ocp_version": {
+            "type": "string"
+          },
+          "hosting_platform": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "residency_request": {
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "start_date": {
-          "type": "string"
+          "type": "string",
+          "format": "date"
         },
         "end_date": {
-          "type": "string"
+          "type": "string",
+          "format": "date"
         },
         "cluster_ref": {
           "type": "string"
@@ -578,12 +669,43 @@
         }
       }
     },
-    "groups": {
+    "residency_response": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "cluster_ref": {
+            "type": "string"
+          },
+          "source_control": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "group_request": {
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "group_name": {
           "type": "string"
         },
@@ -595,6 +717,46 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "group_response": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "group_name": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "delete_response": {
+      "properties": {
+        "n": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "ok": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "deletedCount": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     }

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1,0 +1,172 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Open Management Portal",
+    "description": "Open Management Portal for Swagger",
+    "termsOfService": "http://swagger.io/terms/"
+  },
+  "basePath": "/",
+  "tags" : [
+    {"name": "Tag1", 
+    "description": "API for something"
+    }
+  ],
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/path/to/method": {
+       "post": {
+          "tags": ["Tag1"],
+          "description": "what this API does",
+          "operationId": "for the URL",
+          "produces": [
+            "application/json"
+          ],
+          "parameters": [
+              {
+                "name": "Job Parameters",
+                "in": "body",
+                "description": "Job to add to the database",
+                "required": true,
+              "schema": {
+                "$ref": "#/definitions/create"
+                }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "create response",
+              "schema": {
+                 "$ref": "#/definitions/response"
+              }
+            }
+          }
+        }
+    },
+    "/path/to/method/{someVariable}": {
+        "delete":{
+          "tags":["Tag1"],
+          "description":"Deletes a something",
+          "operationId":"delete",
+          "produces": [
+            "application/json"
+          ],
+          "parameters":[
+              {
+                "name": "someVariable",
+                "in": "path",
+                "description": "ID to delete",
+                "required": true,
+                "type": "string"
+              }
+            ],
+          "responses": {
+            "200": {
+              "description": "delete response",
+              "schema":{
+                "$ref":"#/definitions/deleteRes"
+              }
+            }
+          }
+        },
+      "get":{
+          "tags": [ "Tag1"],
+          "description": "Returns the status of something",
+          "operationId": "findById",
+          "produces": [
+            "application/json"
+          ],
+          "parameters": [
+              {
+                "name": "ID",
+                "in": "path",
+                "description": "ID to fetch",
+                "required": true,
+                "type": "string"
+              }
+            ],
+        "responses": {
+            "200": {
+              "description": "response",
+              "schema": {
+                "$ref": "#/definitions/response1"
+              }
+            }
+          }
+        }
+      }
+  },
+  "definitions": {
+    "create": {
+      "properties": {
+        "eventId": {
+          "required":true,
+          "type": "string",
+          "example": "mathmaticial"
+        },
+        "numberRequired": {
+          "required":true,
+          "type":"integer",
+          "format": "int64",
+          "example": 500
+        } 
+      }
+    },
+    "response1": {
+        "properties": {
+          "jobID": {
+            "required":true,
+            "type": "string",
+            "example": "23423456543"
+          },
+          "request": {
+            "required":true,
+            "type": "schema",
+            "example": {
+              "eventId":"mathmaticial",
+              "numberRequired": 500
+            }
+          }
+      }
+    },
+    "response": {
+        "properties": {
+            "jobID": {
+              "required": true,
+              "type" : "string",
+              "example" : "12321432423"
+            }
+        }
+    },
+    "delete": {
+        "properties": {
+            "jobID": {
+              "required": true,
+              "type" : "string",
+              "example" : "234344234234"
+            },
+            "status" : {
+              "required": true,
+              "type": "string",
+              "example": "deleted"
+            }
+        }
+    },
+    "400error" : {
+       "properties": {
+        "message": {
+          "type": "string",
+          "example" : "400 Bad Request"
+        }
+      }
+    }
+  }
+}

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -6,10 +6,27 @@
     "description": "Open Management Portal for Swagger",
     "termsOfService": "http://swagger.io/terms/"
   },
-  "basePath": "/",
-  "tags" : [
-    {"name": "Tag1", 
-    "description": "API for something"
+  "basePath": "/api/v1",
+  "tags": [
+    {
+      "name": "Users",
+      "description": "Residency members"
+    },
+    {
+      "name": "Customers",
+      "description": "Labs Customer Name"
+    },
+    {
+      "name": "Clusters",
+      "description": "OpenShift Cluster Specifics"
+    },
+    {
+      "name": "Residencies",
+      "description": "Name and information about a Residency"
+    },
+    {
+      "name": "Groups",
+      "description": "Group name"
     }
   ],
   "schemes": [
@@ -22,149 +39,562 @@
     "application/json"
   ],
   "paths": {
-    "/path/to/method": {
-       "post": {
-          "tags": ["Tag1"],
-          "description": "what this API does",
-          "operationId": "for the URL",
-          "produces": [
-            "application/json"
-          ],
-          "parameters": [
-              {
-                "name": "Job Parameters",
-                "in": "body",
-                "description": "Job to add to the database",
-                "required": true,
-              "schema": {
-                "$ref": "#/definitions/create"
-                }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "create response",
-              "schema": {
-                 "$ref": "#/definitions/response"
-              }
+    "/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "description": "Returns the status of something",
+        "operationId": "get_user",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ID",
+            "in": "path",
+            "description": "ID to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/customers"
             }
           }
         }
-    },
-    "/path/to/method/{someVariable}": {
-        "delete":{
-          "tags":["Tag1"],
-          "description":"Deletes a something",
-          "operationId":"delete",
-          "produces": [
-            "application/json"
-          ],
-          "parameters":[
-              {
-                "name": "someVariable",
-                "in": "path",
-                "description": "ID to delete",
-                "required": true,
-                "type": "string"
-              }
-            ],
-          "responses": {
-            "200": {
-              "description": "delete response",
-              "schema":{
-                "$ref":"#/definitions/deleteRes"
-              }
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "description": "what this API does",
+        "operationId": "post_user",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Job Parameters",
+            "in": "body",
+            "description": "Job to add to the database",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/customers"
             }
           }
-        },
-      "get":{
-          "tags": [ "Tag1"],
-          "description": "Returns the status of something",
-          "operationId": "findById",
-          "produces": [
-            "application/json"
-          ],
-          "parameters": [
-              {
-                "name": "ID",
-                "in": "path",
-                "description": "ID to fetch",
-                "required": true,
-                "type": "string"
-              }
-            ],
+        ],
         "responses": {
-            "200": {
-              "description": "response",
-              "schema": {
-                "$ref": "#/definitions/response1"
-              }
+          "200": {
+            "description": "create response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "description": "Deletes a something",
+        "operationId": "delete_user",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "someVariable",
+            "in": "path",
+            "description": "ID to delete",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "delete response",
+            "schema": {
+              "$ref": "#/definitions/customers"
             }
           }
         }
       }
+    },
+    "/customers": {
+      "get": {
+        "tags": [
+          "Customers"
+        ],
+        "description": "Returns the status of something",
+        "operationId": "get_customer",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ID",
+            "in": "path",
+            "description": "ID to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Customers"
+        ],
+        "description": "what this API does",
+        "operationId": "post_customer",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Job Parameters",
+            "in": "body",
+            "description": "Job to add to the database",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Customers"
+        ],
+        "description": "Deletes a something",
+        "operationId": "delete_customer",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "someVariable",
+            "in": "path",
+            "description": "ID to delete",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "delete response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      }
+    },
+    "/clusters": {
+      "get": {
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Returns the status of something",
+        "operationId": "get_cluster",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ID",
+            "in": "path",
+            "description": "ID to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Clusters"
+        ],
+        "description": "what this API does",
+        "operationId": "post_cluster",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Job Parameters",
+            "in": "body",
+            "description": "Job to add to the database",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Deletes a something",
+        "operationId": "delete_cluster",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "someVariable",
+            "in": "path",
+            "description": "ID to delete",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "delete response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      }
+    },
+    "/residencies": {
+      "get": {
+        "tags": [
+          "Residencies"
+        ],
+        "description": "Returns the status of something",
+        "operationId": "get_residency",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ID",
+            "in": "path",
+            "description": "ID to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Residencies"
+        ],
+        "description": "what this API does",
+        "operationId": "post_residency",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Job Parameters",
+            "in": "body",
+            "description": "Job to add to the database",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Residencies"
+        ],
+        "description": "Deletes a something",
+        "operationId": "delete_residency",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "someVariable",
+            "in": "path",
+            "description": "ID to delete",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "delete response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      }
+    },
+    "/groups": {
+      "get": {
+        "tags": [
+          "Groups"
+        ],
+        "description": "Returns the status of something",
+        "operationId": "get_group",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ID",
+            "in": "path",
+            "description": "ID to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Groups"
+        ],
+        "description": "what this API does",
+        "operationId": "post_group",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Job Parameters",
+            "in": "body",
+            "description": "Job to add to the database",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Groups"
+        ],
+        "description": "Deletes a something",
+        "operationId": "delete_group",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "someVariable",
+            "in": "path",
+            "description": "ID to delete",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "delete response",
+            "schema": {
+              "$ref": "#/definitions/customers"
+            }
+          }
+        }
+      }
+    }
   },
   "definitions": {
-    "create": {
+    "users": {
+      "type": "object",
       "properties": {
-        "eventId": {
-          "required":true,
-          "type": "string",
-          "example": "mathmaticial"
+        "id": {
+          "type": "integer",
+          "format": "int64"
         },
-        "numberRequired": {
-          "required":true,
-          "type":"integer",
-          "format": "int64",
-          "example": 500
-        } 
-      }
-    },
-    "response1": {
-        "properties": {
-          "jobID": {
-            "required":true,
-            "type": "string",
-            "example": "23423456543"
-          },
-          "request": {
-            "required":true,
-            "type": "schema",
-            "example": {
-              "eventId":"mathmaticial",
-              "numberRequired": 500
-            }
+        "user_name": {
+          "type": "string"
+        },
+        "first_name": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        },
+        "expiration_date": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "identity_providers": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
+        }
       }
     },
-    "response": {
-        "properties": {
-            "jobID": {
-              "required": true,
-              "type" : "string",
-              "example" : "12321432423"
-            }
+    "customers": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "customer_name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
+      }
     },
-    "delete": {
-        "properties": {
-            "jobID": {
-              "required": true,
-              "type" : "string",
-              "example" : "234344234234"
-            },
-            "status" : {
-              "required": true,
-              "type": "string",
-              "example": "deleted"
-            }
+    "clusters": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "logging": {
+          "type": "boolean"
+        },
+        "metrics": {
+          "type": "boolean"
+        },
+        "size": {
+          "type": "string"
+        },
+        "ha": {
+          "type": "boolean"
+        },
+        "ocp_version": {
+          "type": "string"
+        },
+        "hosting_platform": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
+      }
     },
-    "400error" : {
-       "properties": {
-        "message": {
-          "type": "string",
-          "example" : "400 Bad Request"
+    "residencies": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "start_date": {
+          "type": "string"
+        },
+        "end_date": {
+          "type": "string"
+        },
+        "cluster_ref": {
+          "type": "string"
+        },
+        "source_control": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "groups": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "group_name": {
+          "type": "string"
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }


### PR DESCRIPTION
#### What does this PR do?
Adds swagger spec to document omp-data-api usage.

#### How should this be tested?
The swagger spec can be viewed at `<omp-data-api-url>/api-docs`. There is a bit of a race condition here as you will need to build from the branch on my fork rather than master. This can be achieved by editing the `build` var in `.openshift-applier/inventory/group_vars/all.yml` to the following:

```
build:
  NAME: "{{ app_name }}"
  PIPELINE_SOURCE_REPOSITORY_URL: https://github.com/bvkin/omp-data-api
  PIPELINE_SOURCE_REPOSITORY_REF: swagger-spec
  S2I_BASE_IMAGE: nodejs:10
```
After setting this, login to your OpenShift cluster and deploy by running the `run.sh` script.
 
#### Is there a relevant Issue open for this?
#7 #9 

#### Who would you like to review this?
cc: @rht-labs/omp
